### PR TITLE
Adding safe uri to write to. Fixes #3.

### DIFF
--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+deploy_vsix.ps1

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -8,3 +8,6 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
+eslint.diff
+deploy_vsix.ps1
+out/src

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -16,7 +16,7 @@
     "bugs": {
         "url": "https://github.com/rbrisita/codio-sui/projects/2"
     },
-    "version": "0.5.2",
+    "version": "0.5.3",
     "license": "MIT",
     "publisher": "rbrisita",
     "icon": "media/icon.png",

--- a/vscode/src/filesystem/workspace.ts
+++ b/vscode/src/filesystem/workspace.ts
@@ -1,6 +1,7 @@
+import * as vscode from 'vscode';
 import { workspace, Uri } from 'vscode';
 import { showCodioNameInputBox, UI, MESSAGES } from '../user_interface/messages';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { ensureDir } from './saveProjectFiles';
 import { existsSync } from 'fs';
 
@@ -10,17 +11,17 @@ const createWorkspaceCodiosFolder = async (workspaceUri: Uri) => {
   return codioWorkspaceFolder;
 };
 
-export const getWorkspaceUriAndCodioDestinationUri = async () => {
-  let workspaceUri = null;
-  let codioUri = null;
-  let getCodioName = null;
+export const getWorkspaceUriAndCodioDestinationUri = async (): Promise<Record<string, unknown>> => {
+  let workspaceUri: Uri = null;
+  let codioUri: Uri = null;
+  let getCodioName: () => Promise<string> = null;
 
   if (workspace.workspaceFolders) {
-    const name = await showCodioNameInputBox();
+    let name = await showCodioNameInputBox();
     if (name) {
       workspaceUri = workspace.workspaceFolders[0].uri;
-      const codioWorkspaceFolderPath = await createWorkspaceCodiosFolder(workspaceUri);
-      codioUri = Uri.file(join(codioWorkspaceFolderPath, `${name.split(' ').join('_')}.codio`));
+      codioUri = await getAvailableUri(name, workspaceUri);
+      name = basename(codioUri.path, '.codio');
       getCodioName = async () => name;
     }
   } else {
@@ -29,6 +30,37 @@ export const getWorkspaceUriAndCodioDestinationUri = async () => {
 
   return { workspaceUri, codioUri, getCodioName };
 };
+
+/**
+ * Get a URI that does not exist and safe to write to.
+ * @param name Name to save codio to.
+ * @param workspaceUri Workspace folder to save codio to.
+ * @returns A safe URI to write the new given codio to.
+ */
+const getAvailableUri = async (name: string, workspaceUri: Uri): Promise<vscode.Uri> => {
+  let uri: Uri;
+  let append = '';
+  let count = 0;
+  let filename;
+  let fileStat: vscode.FileStat;
+  const codioWorkspaceFolderPath = await createWorkspaceCodiosFolder(workspaceUri);
+
+  do {
+    filename = `${name.split(' ').join('_')}${append}.codio`;
+    uri = Uri.file(join(codioWorkspaceFolderPath, filename));
+    try {
+      fileStat = await vscode.workspace.fs.stat(uri);
+      if (fileStat.type === vscode.FileType.File) {
+        count++;
+        append = `_${count.toString().padStart(2, '0')}`;
+      }
+    } catch (e) { // File doesn't exist and available to write to.
+      fileStat = null;
+    }
+  } while (fileStat);
+
+  return uri;
+}
 
 export const getWorkspaceRootAndCodiosFolder = ():
   | { workspaceRootUri: Uri; workspaceCodiosFolder: string }


### PR DESCRIPTION
Decided to just append a number to support the most likely use of writing the same file name to have different parts to a codio.

```shell
react
react_01
react_02
```