### PR TITLE
Remove FSManager Update on Context Change

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -16,7 +16,7 @@
     "bugs": {
         "url": "https://github.com/rbrisita/codio-sui/projects/2"
     },
-    "version": "0.5.6",
+    "version": "0.5.7",
     "license": "MIT",
     "publisher": "rbrisita",
     "icon": "media/icon.png",

--- a/vscode/src/player/Player.ts
+++ b/vscode/src/player/Player.ts
@@ -84,7 +84,6 @@ export default class Player {
    */
   private updateContext(context: string, value: any): void {
     commands.executeCommand('setContext', context, value);
-    FSManager.update();
   }
 
   /**


### PR DESCRIPTION
Removing call to tree data provider update as it invalidates cached values on context update. Fixes #12.

Seems that it is not need to call a refresh for updated context values to take affect.